### PR TITLE
ユーザ検索APIの作成

### DIFF
--- a/controller/userController.go
+++ b/controller/userController.go
@@ -13,6 +13,10 @@ type RequestSignUp struct {
 	Device string `json:"device_name"`
 }
 
+type RequestGetUsers struct {
+	Word string `form:"search_word"`
+}
+
 // SignUp 要求に基づいてユーザを作成する
 func (ctrler Controller) SignUp(c *gin.Context) {
 	dbConn := ctrler.conn //DB接続
@@ -55,5 +59,42 @@ func (ctrler Controller) SignUp(c *gin.Context) {
 
 // GetUsers ユーザ検索API
 func (ctrler Controller) GetUsers(c *gin.Context) {
+	dbConn := ctrler.conn //DB接続
+	req := RequestGetUsers{}
+	err := c.ShouldBind(&req)
 
+	// requestが正しい構造であるか否か
+	if err != nil {
+		response := CreateResponse(400, "bad request", nil)
+		c.JSON(http.StatusOK, response)
+		return
+	}
+
+	// requestが条件を満たしているか否か
+	if req.Word == "" {
+		response := CreateResponse(400, "bad request", nil)
+		c.JSON(http.StatusOK, response)
+		return
+	}
+
+	// ユーザの検索
+	users := []db.User{}
+	count := 0
+	dbConn.Where("name like ?", "%"+req.Word+"%").Find(&users).Count(&count)
+
+	// 該当するユーザが見つからないとき
+	if count == 0 {
+		response := CreateResponse(404, "user not found", nil)
+		c.JSON(http.StatusOK, response)
+		return
+	}
+
+	// 該当するユーザが見つかった時
+	resultUsers := []string{}
+	for _, user := range users {
+		resultUsers = append(resultUsers, user.Name)
+	}
+
+	response := CreateResponse(200, "user found", resultUsers)
+	c.JSON(http.StatusOK, response)
 }

--- a/controller/userController.go
+++ b/controller/userController.go
@@ -52,3 +52,8 @@ func (ctrler Controller) SignUp(c *gin.Context) {
 	response := CreateResponse(200, "user created", nil)
 	c.JSON(http.StatusOK, response)
 }
+
+// GetUsers ユーザ検索API
+func (ctrler Controller) GetUsers(c *gin.Context) {
+
+}

--- a/route/routes.go
+++ b/route/routes.go
@@ -19,6 +19,7 @@ func Init(conn *gorm.DB) *gin.Engine {
 		api.GET("/message/get", ctrler.GetMessage)
 		api.POST("/user/signup", ctrler.SignUp)
 		api.POST("/message/post", ctrler.PostMessage)
+		api.GET("/user/get", ctrler.GetUsers)
 	}
 
 	return r


### PR DESCRIPTION
## やったこと
* #23 に関する変更
* ユーザ検索に利用するAPIを作成した

## できること
###  エンドポイント
* GET /api/user/get

### リクエスト
* search_word(検索語)
* ex)
```localhost:3000/api/user/get?search_word=user&```

### レスポンス
* code:200
  * result(ユーザ名の配列)
* code:404
  * 該当ユーザなし
* code:400
  * リクエストの不備