### PR TITLE
findでレコードがないときのバグを修正

### DIFF
--- a/controller/messageController.go
+++ b/controller/messageController.go
@@ -71,7 +71,8 @@ func (ctrler Controller) PostMessage(c *gin.Context) {
 	if req.To_all_users == true {
 		dbConn.Find(&toUser)
 	} else {
-		if dbConn.Where("name in (?)", req.To_user).Find(&toUser).RecordNotFound() {
+		dbConn.Where("name in (?)", req.To_user).Find(&toUser)
+		if len(toUser) == 0 {
 			response := CreateResponse(404, "to user is not found", nil)
 			c.JSON(http.StatusOK, response)
 			return


### PR DESCRIPTION
# やったこと
* #30 で発覚したRecordNotFound()の予期しない動作を解決
## 変更内容
* Find()でのRecordNotFound()の使用をやめて、SELECTしたレコードの配列数で分岐するように変更

