### PR TITLE
BLE単体についての情報を返却するAPIを作成

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   * GORM
   * Gin
   * mysql
-  
+
 ## 実行
 ### データベースの設定
 * データベース作成
@@ -42,5 +42,5 @@ go run main.go
 * https://github.com/EIMIKI/dropout_s_back/pull/22
 ### メッセージ取得
 * https://github.com/EIMIKI/dropout_s_back/pull/30
-### BLE取得
+### 全BLE取得
 * https://github.com/EIMIKI/dropout_s_back/pull/15

--- a/controller/bleController.go
+++ b/controller/bleController.go
@@ -13,8 +13,8 @@ type ResponseBles struct {
 	AreaName string `json:"area_name"`
 }
 
-// GetBle データベースにあるBLEの一覧を返す
-func (ctrler Controller) GetBle(c *gin.Context) {
+// GetBleAll データベースにあるBLEの一覧を返す
+func (ctrler Controller) GetBleAll(c *gin.Context) {
 	dbConn := ctrler.conn //DB接続
 	ctrler.mux.Lock()
 	defer ctrler.mux.Unlock()

--- a/controller/bleController.go
+++ b/controller/bleController.go
@@ -7,6 +7,11 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// RequestGetBle BLE取得apiへのリクエスト
+type RequestGetBle struct {
+	UUID string `form:"ble_uuid"`
+}
+
 // ResponseBles 返却するBLE情報
 type ResponseBles struct {
 	Name     string `json:"ble_uuid"`
@@ -42,5 +47,46 @@ func (ctrler Controller) GetBleAll(c *gin.Context) {
 	}
 
 	response := CreateResponse(200, "request completed", result)
+	c.JSON(http.StatusOK, response)
+}
+
+// GetBle BLE検索API
+func (ctrler Controller) GetBle(c *gin.Context) {
+	dbConn := ctrler.conn //DB接続
+
+	ctrler.mux.Lock()
+	defer ctrler.mux.Unlock()
+	c.Header("Access-Control-Allow-Origin", "*")
+
+	req := RequestGetBle{}
+	err := c.ShouldBind(&req)
+
+	// requestが正しい構造であるか否か
+	if err != nil {
+		response := CreateResponse(400, "bad request1", nil)
+		c.JSON(http.StatusOK, response)
+		return
+	}
+
+	//requestが条件を満たしているか否か
+	if req.UUID == "" {
+		response := CreateResponse(400, "bad request2", nil)
+		c.JSON(http.StatusOK, response)
+		return
+	}
+
+	// BLEの検索
+	ble := db.Ble{}
+	count := 0
+	dbConn.Where("name=?", req.UUID).First(&ble).Count(&count)
+
+	// 該当するBLEが見つからないとき
+	if count == 0 {
+		response := CreateResponse(404, "BLE not found", nil)
+		c.JSON(http.StatusOK, response)
+		return
+	}
+
+	response := CreateResponse(200, "BLE found", gin.H{"ble_uuid": ble.Name, "area_name": ble.AreaName})
 	c.JSON(http.StatusOK, response)
 }

--- a/route/routes.go
+++ b/route/routes.go
@@ -24,6 +24,7 @@ func Init(conn *gorm.DB) *gin.Engine {
 	api := authorized.Group("/api")
 	{
 		api.GET("/ble/get", ctrler.GetBle)
+		api.GET("/ble/getall", ctrler.GetBleAll)
 		api.GET("/message/get", ctrler.GetMessage)
 		api.POST("/user/signup", ctrler.SignUp)
 		api.POST("/message/post", ctrler.PostMessage)


### PR DESCRIPTION
## やったこと
* #34 についての変更
* 従来のBLE取得APIを名称変更した
* 新規にBLE単体について情報を返すAPIを作成した

## できること
### リクエスト
* ble_uuid(BLEのUUID)
* ex)
```
localhost:3000/api/ble/get?ble_uuid=Beacon1&
```

### レスポンス

* 200
  * ble_uuid
  * area_name(部屋名等)
* 400
  * リクエストの不備
* 404
  * 該当するBLEが発見できない